### PR TITLE
META.{json,yaml}: Deprecate distribution for good.

### DIFF
--- a/META.json
+++ b/META.json
@@ -103,5 +103,6 @@
          "url" : "https://github.com/ronsavage/GraphViz"
       }
    },
-   "version" : "2.18"
+   "version" : "2.18",
+   "x_deprecated": "1"
 }

--- a/META.yml
+++ b/META.yml
@@ -69,3 +69,4 @@ resources:
   license: http://www.perlfoundation.org/artistic_license_2_0
   repository: https://github.com/ronsavage/GraphViz
 version: '2.18'
+x_deprecated: '1'


### PR DESCRIPTION
Hi Ron

This is a PR to deprecate GraphViz for good and mark it deprecated for MetaCPAN.
See this post from Neil Bowers for more info.

http://neilb.org/2015/01/17/deprecated-metadata.html

Cheers!
